### PR TITLE
Fix link to tabs component

### DIFF
--- a/www/src/docs/NavDocs.mdx
+++ b/www/src/docs/NavDocs.mdx
@@ -207,7 +207,7 @@ import NavApi from "./NavApi";
   <Example title="Tabs">
     <Example.Intro>
       Visually represent nav items as "tabs". This style pairs nicely with
-      tabbable regions created by our [Tab components](../tabs/).
+      tabbable regions created by our [Tab components](./tabs).
 
       Note: creating a vertical nav (`.flex-column`) with tabs styling is unsupported by Bootstrap's default stylesheet.
     </Example.Intro>


### PR DESCRIPTION
Currently the generated link is:

https://solid-libs.github.io/solid-bootstrap/tabs/

This PR is intended to change that to the correct path which is:

https://solid-libs.github.io/solid-bootstrap/components/tabs